### PR TITLE
docs: align SuperDoc attribution with brand.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # docx-corpus
 
-The largest open corpus of .docx files (~800K documents) for document processing research. Built by [SuperDoc](https://superdoc.dev).
+The largest open corpus of .docx files (~800K documents) for document processing research. Built by [SuperDoc](https://superdoc.dev) — the document engine for DOCX files.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -261,4 +261,4 @@ MIT
 
 ---
 
-Built by 🦋 [SuperDoc](https://superdoc.dev)
+Built by [SuperDoc](https://superdoc.dev) — the document engine for DOCX files.

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -888,7 +888,7 @@
       <h1>The largest classified corpus of Word documents</h1>
       <p class="hero-sub">.docx files from the public web, classified into document types and topics across dozens of
         languages.</p>
-      <p class="hero-by">Built by 🦋 <a href="https://superdoc.dev/?utm_source=docxcorp.us&utm_medium=referral&utm_campaign=hero">SuperDoc</a></p>
+      <p class="hero-by">Built by <a href="https://superdoc.dev/?utm_source=docxcorp.us&utm_medium=referral&utm_campaign=hero">SuperDoc</a> — the document engine for DOCX files.</p>
       <div class="numbers">
         <div>
           <div class="num-val" id="stat-docs"><span class="skeleton skeleton-num"></span></div>
@@ -981,7 +981,7 @@ curl "https://api.docxcorp.us/manifest?type=legal&amp;lang=en&amp;min_confidence
   </div>
 
   <div class="site-footer">
-    <span>Built by <a href="https://superdoc.dev/?utm_source=docxcorp.us&utm_medium=referral&utm_campaign=footer">SuperDoc</a></span>
+    <span>Built by <a href="https://superdoc.dev/?utm_source=docxcorp.us&utm_medium=referral&utm_campaign=footer">SuperDoc</a> — the document engine for DOCX files.</span>
     <span>Takedown requests: <a href="mailto:help@docxcorp.us">help@docxcorp.us</a></span>
   </div>
 
@@ -990,7 +990,7 @@ curl "https://api.docxcorp.us/manifest?type=legal&amp;lang=en&amp;min_confidence
       <div class="preview-header">
         <div class="preview-title" id="preview-title">document.docx</div>
         <div class="preview-actions">
-          <span class="preview-badge">Powered by<a href="https://superdoc.dev/?utm_source=docxcorp.us&utm_medium=referral&utm_campaign=preview" target="_blank">🦋 SuperDoc</a></span>
+          <span class="preview-badge">Powered by <a href="https://superdoc.dev/?utm_source=docxcorp.us&utm_medium=referral&utm_campaign=preview" target="_blank">SuperDoc</a></span>
           <a class="preview-dl" id="preview-dl" href="#" download>Download</a>
           <button class="preview-close" id="preview-close">Close</button>
         </div>

--- a/apps/web/llms.txt
+++ b/apps/web/llms.txt
@@ -6,7 +6,7 @@ docx-corpus is an open dataset of 736K+ .docx files collected from the public we
 
 Documents are classified using ModernBERT with an average confidence of 82%.
 
-Built by [SuperDoc](https://www.superdoc.dev), the document rendering engine.
+Built by [SuperDoc](https://www.superdoc.dev), the document engine for DOCX files.
 
 ## Document Types
 

--- a/apps/web/scripts/generate-pages.ts
+++ b/apps/web/scripts/generate-pages.ts
@@ -334,7 +334,7 @@ function sharedHeader(activeKind: "type" | "topic"): string {
 function sharedFooter(): string {
   return `
   <div class="site-footer">
-    <span>Built by <a href="https://superdoc.dev/?utm_source=docxcorp.us&utm_medium=referral&utm_campaign=footer">SuperDoc</a></span>
+    <span>Built by <a href="https://superdoc.dev/?utm_source=docxcorp.us&utm_medium=referral&utm_campaign=footer">SuperDoc</a> — the document engine for DOCX files.</span>
     <span>Takedown requests: <a href="mailto:help@docxcorp.us">help@docxcorp.us</a></span>
   </div>`;
 }
@@ -511,7 +511,7 @@ function renderPage(data: PageData): string {
         A collection of ${fmt(total)}+ ${label.toLowerCase()} Word documents from the public web.
         ${esc(description)}
       </p>
-      <p class="hero-by">Built by 🦋 <a href="https://superdoc.dev/?utm_source=docxcorp.us&utm_medium=referral&utm_campaign=hero">SuperDoc</a></p>
+      <p class="hero-by">Built by <a href="https://superdoc.dev/?utm_source=docxcorp.us&utm_medium=referral&utm_campaign=hero">SuperDoc</a> — the document engine for DOCX files.</p>
       <div class="numbers">
         <div><div class="num-val">${fmt(total)}</div><div class="num-label">documents</div></div>
         <div><div class="num-val">${langCount}</div><div class="num-label">languages</div></div>
@@ -592,7 +592,7 @@ function renderIndexPage(
         The docx-corpus dataset classifies documents into ${items.length} ${kindPlural.toLowerCase()}.
         Click on any ${kind} to explore its documents, language distribution, and download options.
       </p>
-      <p class="hero-by">Built by 🦋 <a href="https://superdoc.dev/?utm_source=docxcorp.us&utm_medium=referral&utm_campaign=hero">SuperDoc</a></p>
+      <p class="hero-by">Built by <a href="https://superdoc.dev/?utm_source=docxcorp.us&utm_medium=referral&utm_campaign=hero">SuperDoc</a> — the document engine for DOCX files.</p>
     </section>
     <div class="index-grid">${cards}
     </div>


### PR DESCRIPTION
- Add "the document engine for DOCX files" descriptor to all "Built by SuperDoc" attributions (hero, footer, generated pages)
- llms.txt: "document rendering engine" → "document engine for DOCX files"
- Remove butterfly emoji from attributions