### PR TITLE
fix(ci): upload site files without bucket-root sync

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -40,12 +40,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Non-HTML assets: sync with their natural extensions and content types.
-          # No --delete: the bucket also holds /documents/ and /extracted/ which
-          # are scraper-managed and must not be touched by this workflow.
-          aws s3 sync apps/web/dist/ "$R2_BUCKET/" \
-            --exclude "*.html" \
-            --endpoint-url "$R2_ENDPOINT"
+          # Non-HTML assets: copy the finite Astro output directly. Do not use
+          # `aws s3 sync` at the bucket root because the same bucket also stores
+          # the million-plus scraper-managed /documents/ and /extracted/ objects.
+          find apps/web/dist -type f ! -name "*.html" -print0 | while IFS= read -r -d '' f; do
+            rel="${f#apps/web/dist/}"
+            aws s3 cp "$f" "$R2_BUCKET/$rel" \
+              --endpoint-url "$R2_ENDPOINT"
+          done
 
           # HTML files: upload to extensionless keys to match canonical URLs.
           # /classification.html -> r2://classification, /types/legal.html -> r2://types/legal.


### PR DESCRIPTION
## Summary
- replace the bucket-root `aws s3 sync` in `deploy-site.yml` with direct per-file uploads from `apps/web/dist`
- keep extensionless HTML uploads unchanged
- avoid listing the corpus bucket, which also contains scraper-managed `/documents/` and `/extracted/` objects

## Verification
- `git diff --check`
- extracted workflow shell block passes `bash -n`
- pre-push hook passed: scraper tests, CLI tests, scraper build, CLI build

## Production context
PR #9 merged, but the production deploy hung in the R2 upload step. I cancelled run 26108067134 after the Astro build had completed and before the upload finished.