### PR TITLE
docs(web): note browser_ttl: respect_origin in Cache Rule

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -33,7 +33,13 @@ The Cache Rule is set outside this repo:
 
 - Phase: `http_request_cache_settings`
 - Expression: `http.host eq "docxcorp.us" and (http.request.uri.path eq "/" or http.request.uri.path in {"/dataset" "/classification" "/quality" "/download" "/types" "/topics" "/sitemap.xml" "/robots.txt" "/llms.txt"} or starts_with(http.request.uri.path, "/types/") or starts_with(http.request.uri.path, "/topics/"))`
-- Action: `cache: true`, `edge_ttl.mode: bypass_by_default` (TTL driven by origin `Cache-Control`)
+- Action: `cache: true`, `edge_ttl.mode: bypass_by_default`, `browser_ttl.mode: respect_origin` (both TTLs driven by origin `Cache-Control`)
+
+The `browser_ttl: respect_origin` setting is required because Cloudflare's zone-level Browser
+Cache TTL default (4 hours) would otherwise override the origin's lower `max-age=300`. Without
+it, returning visitors would cache HTML for 4 hours after each deploy. `respect_origin` keeps
+the zone default in effect for paths NOT matched by this rule (favicons, og-image, raw .docx,
+extracted .txt), all of which legitimately want 4-hour browser caching.
 
 The matching upload-side `Cache-Control` header (`public, max-age=300, stale-while-revalidate=3600`)
 is set by `deploy-site.yml` on HTML uploads and on `sitemap.xml`/`robots.txt`/`llms.txt`. Keep the


### PR DESCRIPTION
Documentation-only follow-up to PR #12.

After #12 deployed, live \`Cache-Control\` on HTML pages was \`max-age=14400, stale-while-revalidate=3600\` instead of the documented \`max-age=300, ...\`. Root cause: Cloudflare's zone-level Browser Cache TTL default (4hr) overrode origin's lower \`max-age=300\`. Edge caching worked correctly (origin Cache-Control was honored for edge TTL); only the browser TTL was being inflated.

Fix was a one-line addition to the existing Cache Rule (rule \`b85abcfdb1fa4d07a160e88f7cc4fafd\`, ruleset \`bec0ea98e0444bcaaf518d626b4c47e2\`): \`browser_ttl.mode: respect_origin\`. Verified live before this commit:

- \`/dataset\` now returns \`Cache-Control: public, max-age=300, stale-while-revalidate=3600\` (was 14400)
- \`/favicon.ico\` still returns \`max-age=14400\` (zone default; correct for static asset)
- \`/documents/<hash>.docx\` still returns \`max-age=14400\` + \`x-robots-tag: noindex\` (both correct; content-addressed file legitimately wants 4hr browser cache)

This PR is just the README catching up — the rule fix is already live.