### PR TITLE
feat(web): port homepage to Astro static page (PR 3b)

### DIFF
--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -1,10 +1,24 @@
+---
+// Homepage. Ported from the legacy static apps/web/public/index.html so it
+// participates in the Astro build pipeline. Inline CSS and JS are preserved
+// verbatim under `is:global is:inline` and `is:inline` respectively; the
+// explorer JS still fetches live data from api.docxcorp.us at runtime, same
+// as before.
+//
+// This page intentionally doesn't use the shared Layout.astro because its
+// header/footer chrome and SEO metadata (custom og:title brand tagline,
+// twitter:description with "The missing dataset" copy, full Dataset JSON-LD
+// with variableMeasured/inLanguage/measurementTechnique) differ from the
+// shared one. The other Astro pages still go through Layout.
+---
+
 <!DOCTYPE html>
 <html lang="en">
 
 <head>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-C9QG5MXVL5"></script>
-  <script>
+  <script is:inline>
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
@@ -77,7 +91,7 @@
     as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet"
     href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"></noscript>
-  <style>
+  <style is:global is:inline>
     * {
       margin: 0;
       padding: 0;
@@ -1123,7 +1137,7 @@ curl "https://api.docxcorp.us/manifest?type=legal&amp;lang=en&amp;min_confidence
     </div>
   </div>
 
-  <script>
+  <script is:inline>
     (function () {
       // ---------- state (seed from URL params) ----------
       const _params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
Moves the legacy static homepage into the Astro pipeline. PR 3b from the migration sequence.

**What changes**: \`apps/web/public/index.html\` -> \`apps/web/src/pages/index.astro\`. Git detects the rename (98% similarity). The actual diff is **17 insertions / 3 deletions**:
- Astro frontmatter comment block (no logic, just explaining why this page bypasses Layout.astro)
- 3 inline tag directives: \`<script is:inline>\` x2 + \`<style is:global is:inline>\` x1, so Astro preserves the legacy inline JS/CSS verbatim instead of trying to bundle/transpile them

**What stays the same**: literally everything else. Markup, CSS, JS, SEO meta, OG/Twitter brand tagline, Dataset JSON-LD (with variableMeasured/inLanguage/measurementTechnique), favicon paths, About section's 19 static type/topic links, footer, preview modal, the explorer's runtime fetches to api.docxcorp.us.

**Why no Layout.astro**: the homepage has its own brand chrome (different header/footer markup) and a richer Dataset JSON-LD than the shared one. Forcing it through Layout would require extending Layout with ogTitle/ogDescription/twitterDescription/structuredData overrides for one consumer. Standalone is simpler. The other 25 Astro pages still use Layout.

**Verified locally**:
- \`bun run --cwd apps/web build\` -> 26 pages built in 18s (was 25)
- \`bun run --cwd apps/web typecheck\` -> 0 errors, 0 warnings
- \`dist/index.html\` (43.7 KB, was ~45 KB after Astro's minification): preserves the SEO title, brand-tagline og:title, full JSON-LD, all 19 type/topic links, explorer JS globals

**Smoke test after merge** (auto-deploys via push trigger):
\`\`\`bash
curl -sI https://docxcorp.us/ | grep -iE "HTTP/|content-type|cache-control|cf-cache-status"
curl -s https://docxcorp.us/ | grep -c "renderTypesGrid"   # should be 1+
curl -s https://docxcorp.us/ | grep -oE '<h1>[^<]+</h1>'   # should be the SEO H1
\`\`\`

Then visually verify in browser that the explorer renders (taxonomy grids, document table, manifest download, language bars) - all of that is identical to today's behavior since the JS is byte-for-byte the same.

**Out of scope** (still queued):
- PR 3c (#24): rename \`apps/web\` -> \`apps/site\`, \`apps/web/worker\` -> \`apps/api\`